### PR TITLE
Don't include the full stacktrace of the original exception in the message of the CurlException.

### DIFF
--- a/XML/RPC2/Util/HTTPRequest.php
+++ b/XML/RPC2/Util/HTTPRequest.php
@@ -235,7 +235,7 @@ class XML_RPC2_Util_HTTPRequest
             if ($result->getStatus() != 200) throw new XML_RPC2_ReceivedInvalidStatusCodeException('Received non-200 HTTP Code: ' . $result->getStatus() . '. Response body:' . $result->getBody());
 
         } catch (HTTP_Request2_Exception $e) {
-            throw new XML_RPC2_CurlException($e);
+            throw new XML_RPC2_CurlException($e->getMessage(), 0, $e);
         }
         $this->_body = $result->getBody();
         return $result->getBody();


### PR DESCRIPTION
Don't include the full stacktrace of the original exception in the message of the CurlException.
