### PR TITLE
Fixes incompatibility with new version of package pear/http_request2 2.4.0

### DIFF
--- a/XML/RPC2/Util/HTTPRequest.php
+++ b/XML/RPC2/Util/HTTPRequest.php
@@ -42,7 +42,6 @@
 // dependencies {{{
 require_once 'XML/RPC2/Exception.php';
 require_once 'XML/RPC2/Client.php';
-require_once 'HTTP/Request2.php';
 // }}}
 
 /**

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=5.2.0",
         "pear/pear_exception": "^1.0.0",
-        "pear/http_request2": "^2.3.0"
+        "pear/http_request2": "^2.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*"


### PR DESCRIPTION
Tries to solve incompatibility with new version of package pear/http_request2 2.4.0. Check issue here: https://github.com/pear/HTTP_Request2/issues/18