### PR TITLE
Add missing property to XML_RPC2_Util_HTTPRequest

### DIFF
--- a/XML/RPC2/Util/HTTPRequest.php
+++ b/XML/RPC2/Util/HTTPRequest.php
@@ -119,6 +119,13 @@ class XML_RPC2_Util_HTTPRequest
      */
     private $_httpRequest = null;
 
+    /**
+     * body value
+     *
+     * @var string
+     */
+    private $_body = null;
+
     // }}}
     // {{{ getBody()
 


### PR DESCRIPTION
Fixes `Creation of dynamic property` error.