### PR TITLE
updates fixing handling to clear php deprecated message

### DIFF
--- a/XML/RPC2/Backend/Php/Request.php
+++ b/XML/RPC2/Backend/Php/Request.php
@@ -163,7 +163,7 @@ class XML_RPC2_Backend_Php_Request
 
         $result = '<?xml version="1.0" encoding="' . $this->_encoding . '"?>' . "\n";
         $result .= "<methodCall>";
-        $result .= "<methodName>${methodName}</methodName>";
+        $result .= "<methodName>{$methodName}</methodName>";
         $result .= "<params>";
         foreach($parameters as $parameter) {
             $result .= "<param><value>";

--- a/XML/RPC2/Backend/Xmlrpcext/Client.php
+++ b/XML/RPC2/Backend/Xmlrpcext/Client.php
@@ -126,7 +126,7 @@ class XML_RPC2_Backend_Xmlrpcext_Client extends XML_RPC2_Client
         */
         if (is_array($result) && xmlrpc_is_fault($result)) {
             if ($this->debug) {
-                print "XML_RPC2_FaultException(${result['faultString']}, ${result['faultCode']})";
+                print "XML_RPC2_FaultException({$result['faultString']}, {$result['faultCode']})";
             }
             throw new XML_RPC2_FaultException($result['faultString'], $result['faultCode']);
         }


### PR DESCRIPTION
fix for `PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead` in php8